### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2241,10 +2241,10 @@ MIT
 
 ## Star History
 
-<a href="https://star-history.com/#brycewang-stanford/Awesome-Journal-Skills&Date">
+<a href="https://star-history.dera.page/#brycewang-stanford/Awesome-Journal-Skills&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
   </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -2241,10 +2241,10 @@ MIT
 
 ## Star History
 
-<a href="https://star-history.com/#brycewang-stanford/Awesome-Journal-Skills&Date">
+<a href="https://star-history.dera.page/#brycewang-stanford/Awesome-Journal-Skills&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=brycewang-stanford/Awesome-Journal-Skills&type=Date" />
   </picture>
 </a>


### PR DESCRIPTION
The current star history chart is broken and no longer renders reliably. Update both README variants to restore the chart and keep the repository's star history visible.